### PR TITLE
Set bar chart color conditionally

### DIFF
--- a/src/components/ProgressChart.tsx
+++ b/src/components/ProgressChart.tsx
@@ -14,7 +14,9 @@ const ProgressChart: React.FC<{ data: Array<StepLog>, todayStep: number, stepGoa
 
   // below vars are self documenting
   const stepsLeft = stepGoal - todayStep;
-
+  const style = getComputedStyle(document.documentElement);
+  //primCol contains the color for the text and lines
+  const primCol = style.getPropertyValue('--primaryColor');
   // below is the react element.
   // input/props is an array of step logs
   // output is a react element
@@ -32,27 +34,26 @@ const ProgressChart: React.FC<{ data: Array<StepLog>, todayStep: number, stepGoa
             y: {
               grid: {
                 drawBorder: false,
-                color: '#FFFFFF'
+                color: primCol
               },
               ticks: {
                 beginAtZero: true,
-                color: 'white',
+                color: primCol,
                 fontSize: 12
               }
             },
             x: {
               grid: {
                 drawBorder: false,
-                color: '#FFFFFF'
+                color: primCol
               },
               ticks: {
                 beginAtZero: true,
-                color: 'white',
+                color: primCol,
                 fontSize: 12
               }
             }
           },
-          color: 'white'
         }}
         data={{
           labels: data.map((item) => item.date),

--- a/src/components/progChart.css
+++ b/src/components/progChart.css
@@ -3,3 +3,11 @@
   margin: auto;
   padding: 0.5em;
 }
+:root {
+  --primaryColor: black;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primaryColor: white;
+  }
+}


### PR DESCRIPTION
I changed the bar chart to display black if light mode is enabled or white if dark mode is enabled so that when we put a card behind it, you can see it whether the card is in light mode or dark mode. 
<img width="509" alt="image" src="https://user-images.githubusercontent.com/89169221/224505591-71ab2857-2322-4bf7-944d-fb3cfa2accf0.png">
<img width="504" alt="image" src="https://user-images.githubusercontent.com/89169221/224505607-21284542-0cc7-42a1-b61b-ba0d37a34d1a.png">
