### PR TITLE
Changed cursor to pointer over link

### DIFF
--- a/src/pages/homePage/homePage.css
+++ b/src/pages/homePage/homePage.css
@@ -79,6 +79,10 @@
   }
 }
 
+.link-color{
+  cursor: pointer;
+}
+
 @media (prefers-color-scheme: light) {
   .link-color {
     color: darkgreen;


### PR DESCRIPTION
Cursor changes to a pointer over the link to manual steps logging in the home page. The screenshot takes out my cursor but here's the screenshot anyway. 
<img width="341" alt="image" src="https://user-images.githubusercontent.com/89169221/225466623-0e25ed3f-5a4e-4c4e-bce5-f5e6b8e3098e.png">
