### PR TITLE
Reduced leaderboard font on small screens

### DIFF
--- a/src/components/LeaderBoard/LeaderBoardChart.scss
+++ b/src/components/LeaderBoard/LeaderBoardChart.scss
@@ -33,3 +33,11 @@
     font-size: 40px;
   } 
 }
+
+@media (max-width: 400px) {
+  .title {
+    ion-card-title {
+      font-size: 20px;
+    }
+  }
+}

--- a/src/components/LeaderBoard/TeamLeaderboardChart.scss
+++ b/src/components/LeaderBoard/TeamLeaderboardChart.scss
@@ -33,3 +33,11 @@
     font-size: 40px;
   }
 }
+
+@media (max-width: 400px) {
+  .title {
+    ion-card-title {
+      font-size: 20px;
+    }
+  }
+}


### PR DESCRIPTION
I reduced the font for the leaderboard title on smaller screens so that it doesn't break the word up into two lines. 
<img width="472" alt="image" src="https://user-images.githubusercontent.com/89169221/225491136-5e1d211c-c061-4741-8427-3b6b6d6e77b4.png">
